### PR TITLE
feat: 공통 응답 구조 구현

### DIFF
--- a/src/main/java/com/gonggoo/gonggoo/global/response/ApiResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.gonggoo.gonggoo.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final int status;
+    private final String message;
+    private final T data;
+    private final ErrorDetails errorDetails;
+
+    private  ApiResponse(int status, String message, T data, ErrorDetails errorDetails) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+        this.errorDetails = errorDetails;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), "OK", data, null);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), message, data, null);
+    }
+
+    public static <T> ApiResponse<T> success(HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status.value(), message, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getHttpStatus().value(),
+                errorCode.getMessage(),
+                null,
+                ErrorDetails.of(errorCode));
+    }
+
+}

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.gonggoo.gonggoo.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다.", "User 엔티티가 db 안에 존재하지 않습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String reason;
+
+}

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorDetails.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorDetails.java
@@ -1,0 +1,20 @@
+package com.gonggoo.gonggoo.global.response;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorDetails {
+
+    private final String code;
+    private final String reason;
+
+    private ErrorDetails(String code, String reason) {
+        this.code = code;
+        this.reason = reason;
+    }
+
+    public static ErrorDetails of(ErrorCode errorCode) {
+        return new ErrorDetails(errorCode.name(), errorCode.getReason());
+    }
+
+}


### PR DESCRIPTION
## 🔘 Part
- [ ] FE
- [x] BE
- [ ] Other
## #️⃣ 연관된 이슈
<!-- ex) #123 -->
#9 공통 응답 포맷 개발
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
성공/실패 공통 응답 구조 구현
- ApiResponse 제네릭 구조로 통일
- ErrorCode Enum으로 에러 코드 관리
- ErrorDetails 클래스로 에러 관리(code, reason)
- 성공/실패 응답 정적 팩토리 메서드 제공
## 💬 리뷰 요구사항
- 전반적인 구조와 네이밍이 적절했는지 확인 부탁드립니다
- 추후 확장성 고려했을 때 ErrorCode enum 구조 적절한지(도메인 별로 ErrorCode 분리해야 하는지) 확인 부탁드립니다
- FE 분들이 parsing하기 편하게 data, ErrorDetails를 공통 응답 필드로 두었는데 괜찮은지 확인 부탁드립니다
- message는 사용자 친화적인 메세지, ErrorDetails의 reason은 개발자 친화적인 메세지로 사용했는데 괜찮은지 확인 부탁드립니다