### PR TITLE
Feature/#84 소셜 로그인 api 구현

### DIFF
--- a/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
@@ -30,4 +30,10 @@ public class AuthController {
         return ApiResponse.success("TOKEN_REISSUED", newToken);
 
     }
+
+    @GetMapping("/login/kakao")
+    public ApiResponse<JwtTokenDto> kakaoLogin(@RequestParam("code") String code) {
+        JwtTokenDto kakaoToken = authService.kakaoLogin(code);
+        return ApiResponse.success("LOGIN_SUCCESS", kakaoToken);
+    }
 }

--- a/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
@@ -43,4 +43,10 @@ public class AuthController {
         JwtTokenDto naverToken = authService.naverLogin(code, state);
         return ApiResponse.success("LOGIN_SUCCESS", naverToken);
     }
+
+    @GetMapping("/login/google")
+    public ApiResponse<JwtTokenDto> googleLogin(@RequestParam("code") String code){
+        JwtTokenDto googleToken = authService.googleLogin(code);
+        return ApiResponse.success("LOGIN_SUCCESS", googleToken);
+    }
 }

--- a/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
@@ -36,4 +36,11 @@ public class AuthController {
         JwtTokenDto kakaoToken = authService.kakaoLogin(code);
         return ApiResponse.success("LOGIN_SUCCESS", kakaoToken);
     }
+
+    @GetMapping("/login/naver")
+    public ApiResponse<JwtTokenDto> naverLogin(@RequestParam("code") String code,
+                                               @RequestParam("state") String state) {
+        JwtTokenDto naverToken = authService.naverLogin(code, state);
+        return ApiResponse.success("LOGIN_SUCCESS", naverToken);
+    }
 }

--- a/src/main/java/com/gonggoo/gonggoo/auth/domain/RegistrationProvider.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/domain/RegistrationProvider.java
@@ -1,0 +1,5 @@
+package com.gonggoo.gonggoo.auth.domain;
+
+public enum RegistrationProvider {
+    LOCAL, KAKAO, NAVER, GOOGLE
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleConfig.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleConfig.java
@@ -1,0 +1,9 @@
+package com.gonggoo.gonggoo.auth.google;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(GoogleProps.class)
+public class GoogleConfig {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleProps.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleProps.java
@@ -1,0 +1,14 @@
+package com.gonggoo.gonggoo.auth.google;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.google")
+public record GoogleProps(
+        String client_id,
+        String redirect_uri,
+        String client_secret,
+        String post_uri,
+        String user_info_url,
+        String scope
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleTokenResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleTokenResponse.java
@@ -1,0 +1,10 @@
+package com.gonggoo.gonggoo.auth.google;
+
+public record GoogleTokenResponse(
+        String access_token,
+        int expires_in,
+        String refresh_token,
+        String scope,
+        String token_type
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleUserInfoResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/google/GoogleUserInfoResponse.java
@@ -1,0 +1,11 @@
+package com.gonggoo.gonggoo.auth.google;
+
+public record GoogleUserInfoResponse(
+        String sub,
+        String email,
+        String given_name,
+        String family_name,
+        String name,
+        String picture
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoConfig.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoConfig.java
@@ -1,0 +1,9 @@
+package com.gonggoo.gonggoo.auth.kakao;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(KakaoProps.class)
+public class KakaoConfig {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoProps.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoProps.java
@@ -1,0 +1,13 @@
+package com.gonggoo.gonggoo.auth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoProps(
+        String client_id,
+        String redirect_uri,
+        String client_secret,
+        String post_uri,
+        String user_info_url
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoTokenResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoTokenResponse.java
@@ -1,0 +1,12 @@
+package com.gonggoo.gonggoo.auth.kakao;
+
+public record KakaoTokenResponse(
+        String token_type,
+        String access_token,
+        String id_token,
+        int expires_in,
+        String refresh_token,
+        int refresh_token_expires_in,
+        String scope
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,31 @@
+package com.gonggoo.gonggoo.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+        public record Profile(
+                String nickname,
+                @JsonProperty("thumnail_image_url") String thumnailImageUrl
+        ) {
+        }
+    }
+
+    public String getEmail() {
+        return kakaoAccount().email();
+    }
+
+    public String getNickname() {
+        return kakaoAccount().profile().nickname();
+    }
+
+    public String getProfileImage() {
+        return kakaoAccount().profile().thumnailImageUrl();
+    }
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverConfig.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverConfig.java
@@ -1,0 +1,9 @@
+package com.gonggoo.gonggoo.auth.naver;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(NaverProps.class)
+public class NaverConfig {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverProps.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverProps.java
@@ -1,0 +1,13 @@
+package com.gonggoo.gonggoo.auth.naver;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.naver")
+public record NaverProps(
+        String client_id,
+        String redirect_uri,
+        String client_secret,
+        String post_uri,
+        String user_info_url
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverTokenResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverTokenResponse.java
@@ -1,0 +1,11 @@
+package com.gonggoo.gonggoo.auth.naver;
+
+public record NaverTokenResponse(
+        String access_token,
+        String refresh_token,
+        String token_type,
+        int expires_in,
+        String error,
+        String error_description
+) {
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverUserInfoResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/naver/NaverUserInfoResponse.java
@@ -1,0 +1,36 @@
+package com.gonggoo.gonggoo.auth.naver;
+
+public record NaverUserInfoResponse(
+        String resultcode,
+        String message,
+        Response response
+){
+    public record Response(
+        String email,
+        String nickname,
+        String profile_image,
+        String id,
+        String mobile
+    ){
+    }
+
+    public String email() {
+        return response().email();
+    }
+
+    public String nickname() {
+        return response().nickname();
+    }
+
+    public String profile_image() {
+        return response().profile_image();
+    }
+
+    public String id() {
+        return response().id();
+    }
+
+    public String mobile() {
+        return response().mobile();
+    }
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.gonggoo.gonggoo.auth.service;
 
 import static com.gonggoo.gonggoo.global.response.ErrorCode.KAKAO_USER_INFO_NOT_FOUND;
+import static com.gonggoo.gonggoo.global.response.ErrorCode.NAVER_USER_INFO_NOT_FOUND;
 
 import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.auth.dto.LoginRequest;
@@ -9,6 +10,9 @@ import com.gonggoo.gonggoo.auth.jwt.JwtTokenProvider;
 import com.gonggoo.gonggoo.auth.kakao.KakaoProps;
 import com.gonggoo.gonggoo.auth.kakao.KakaoTokenResponse;
 import com.gonggoo.gonggoo.auth.kakao.KakaoUserInfoResponse;
+import com.gonggoo.gonggoo.auth.naver.NaverProps;
+import com.gonggoo.gonggoo.auth.naver.NaverTokenResponse;
+import com.gonggoo.gonggoo.auth.naver.NaverUserInfoResponse;
 import com.gonggoo.gonggoo.common.domain.Role;
 import com.gonggoo.gonggoo.global.exception.NeighborsException;
 import com.gonggoo.gonggoo.member.domain.Member;
@@ -38,6 +42,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoProps kakaoProps;
+    private final NaverProps naverProps;
     private final RestTemplate restTemplate;
 
     public JwtTokenDto login(LoginRequest loginRequest) {
@@ -132,13 +137,76 @@ public class AuthService {
             );
 
             if(!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                log.debug("response에서 에러 발생" + response);
                 throw new NeighborsException(KAKAO_USER_INFO_NOT_FOUND);
             }
             return response.getBody();
         } catch (RestClientException e) {
-            log.debug("에러 발생: " + e.getMessage());
             throw new NeighborsException(KAKAO_USER_INFO_NOT_FOUND);
+        }
+    }
+
+    public JwtTokenDto naverLogin(String code, String state) {
+        String naverToken = getNaverAccessToken(code);
+        NaverUserInfoResponse userInfo = getNaverUserInfo(naverToken);
+
+        Member member = memberRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> {
+                    return memberRepository.save(Member.builder()
+                            .email(userInfo.email())
+                            .nickname(userInfo.nickname())
+                            .profileImage(userInfo.profile_image())
+                            .provider(RegistrationProvider.NAVER)
+                            .providerId(userInfo.id())
+                            .phoneNumber(userInfo.mobile())
+                            .password(null)
+                            .role(Role.USER)
+                            .status(MemberStatus.ACTIVE)
+                            .build());
+                });
+        JwtTokenDto jwtTokenDto = jwtTokenProvider.generateToken(String.valueOf(member.getId()), member.getRole());
+        return jwtTokenDto;
+    }
+
+    private String getNaverAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", naverProps.client_id());
+        body.add("client_secret", naverProps.client_secret());
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<NaverTokenResponse> response = restTemplate.postForEntity(
+                naverProps.post_uri(),
+                request,
+                NaverTokenResponse.class
+        );
+
+        return response.getBody().access_token();
+    }
+
+    private NaverUserInfoResponse getNaverUserInfo(String naverAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + naverAccessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<NaverUserInfoResponse> response = restTemplate.exchange(
+                    naverProps.user_info_url(),
+                    HttpMethod.GET,
+                    request,
+                    NaverUserInfoResponse.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                throw new NeighborsException(NAVER_USER_INFO_NOT_FOUND);
+            }
+
+            return response.getBody();
+        } catch (RestClientException e) {
+            throw new NeighborsException(NAVER_USER_INFO_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
@@ -1,10 +1,14 @@
 package com.gonggoo.gonggoo.auth.service;
 
+import static com.gonggoo.gonggoo.global.response.ErrorCode.GOOGLE_USER_INFO_NOT_FOUND;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.KAKAO_USER_INFO_NOT_FOUND;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.NAVER_USER_INFO_NOT_FOUND;
 
 import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.auth.dto.LoginRequest;
+import com.gonggoo.gonggoo.auth.google.GoogleProps;
+import com.gonggoo.gonggoo.auth.google.GoogleTokenResponse;
+import com.gonggoo.gonggoo.auth.google.GoogleUserInfoResponse;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenDto;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenProvider;
 import com.gonggoo.gonggoo.auth.kakao.KakaoProps;
@@ -43,6 +47,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoProps kakaoProps;
     private final NaverProps naverProps;
+    private final GoogleProps googleProps;
     private final RestTemplate restTemplate;
 
     public JwtTokenDto login(LoginRequest loginRequest) {
@@ -207,6 +212,75 @@ public class AuthService {
             return response.getBody();
         } catch (RestClientException e) {
             throw new NeighborsException(NAVER_USER_INFO_NOT_FOUND);
+        }
+    }
+
+    public JwtTokenDto googleLogin(String code) {
+        String googleToken = getGoogleAccessToken(code);
+        GoogleUserInfoResponse userInfo = getGoogleUserInfo(googleToken);
+
+        Member member = memberRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> {
+                    return memberRepository.save(Member.builder()
+                            .email(userInfo.email())
+                            .nickname(userInfo.name())
+                            .provider(RegistrationProvider.GOOGLE)
+                            .providerId(userInfo.sub())
+                            .profileImage(userInfo.picture())
+                            .phoneNumber(null)
+                            .role(Role.USER)
+                            .status(MemberStatus.ACTIVE)
+                            .build());
+                });
+
+        JwtTokenDto jwtTokenDto = jwtTokenProvider.generateToken(String.valueOf(member.getId()), member.getRole());
+        return jwtTokenDto;
+    }
+
+    private String getGoogleAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", googleProps.client_id());
+        body.add("client_secret", googleProps.client_secret());
+        body.add("code", code);
+        body.add("grant_type", "authorization_code");
+        body.add("redirect_uri", googleProps.redirect_uri());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<GoogleTokenResponse> response = restTemplate.postForEntity(
+                googleProps.post_uri(),
+                request,
+                GoogleTokenResponse.class
+        );
+
+        return response.getBody().access_token();
+    }
+
+    private GoogleUserInfoResponse getGoogleUserInfo(String googleAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + googleAccessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<GoogleUserInfoResponse> response = restTemplate.exchange(
+                    googleProps.user_info_url(),
+                    HttpMethod.GET,
+                    request,
+                    GoogleUserInfoResponse.class
+            );
+
+            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.debug("GoogleUserResponse 에러", response.getBody());
+                throw new NeighborsException(GOOGLE_USER_INFO_NOT_FOUND);
+            }
+
+            return response.getBody();
+        } catch (RestClientException e) {
+            log.debug("유저 정보 조회 중 에러", e.getMessage());
+            throw new NeighborsException(GOOGLE_USER_INFO_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
@@ -1,16 +1,32 @@
 package com.gonggoo.gonggoo.auth.service;
 
+import static com.gonggoo.gonggoo.global.response.ErrorCode.KAKAO_USER_INFO_NOT_FOUND;
+
+import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.auth.dto.LoginRequest;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenDto;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenProvider;
+import com.gonggoo.gonggoo.auth.kakao.KakaoProps;
+import com.gonggoo.gonggoo.auth.kakao.KakaoTokenResponse;
+import com.gonggoo.gonggoo.auth.kakao.KakaoUserInfoResponse;
 import com.gonggoo.gonggoo.common.domain.Role;
+import com.gonggoo.gonggoo.global.exception.NeighborsException;
 import com.gonggoo.gonggoo.member.domain.Member;
+import com.gonggoo.gonggoo.member.domain.MemberStatus;
 import com.gonggoo.gonggoo.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +37,8 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoProps kakaoProps;
+    private final RestTemplate restTemplate;
 
     public JwtTokenDto login(LoginRequest loginRequest) {
         Member member = memberRepository.findByEmail(loginRequest.email())
@@ -48,5 +66,79 @@ public class AuthService {
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .build();
+    }
+
+    public JwtTokenDto kakaoLogin(String code) {
+        String kakaoAccessToken = getKakaoAccessToken(code);
+        KakaoUserInfoResponse kakaoUserInfo = getKaKaoUserInfo(kakaoAccessToken);
+
+        Member member = memberRepository.findByEmail(kakaoUserInfo.getEmail())
+                .orElseGet(() -> {
+                    return memberRepository.save(Member.builder()
+                            .email(kakaoUserInfo.getEmail())
+                            .nickname(kakaoUserInfo.getNickname())
+                            .profileImage(kakaoUserInfo.getProfileImage())
+                            .provider(RegistrationProvider.KAKAO)
+                            .providerId(String.valueOf(kakaoUserInfo.id()))
+                            .password(null)
+                            .phoneNumber(null)
+                            .role(Role.USER)
+                            .status(MemberStatus.ACTIVE)
+                            .build());
+                });
+
+        JwtTokenDto jwtTokenDto = jwtTokenProvider.generateToken(String.valueOf(member.getId()), member.getRole());
+        return jwtTokenDto;
+    }
+
+    private String getKakaoAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoProps.client_id());
+        body.add("redirect_uri", kakaoProps.redirect_uri());
+        body.add("code", code);
+        body.add("client_secret", kakaoProps.client_secret());
+        log.debug("client_id : " + kakaoProps.client_id());
+        log.debug("redirect_uri : " + kakaoProps.redirect_uri());
+        log.debug("client_secret : " + kakaoProps.client_secret());
+
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.postForEntity(
+                kakaoProps.post_uri(),
+                request,
+                KakaoTokenResponse.class
+        );
+
+        return response.getBody().access_token();
+    }
+
+    private KakaoUserInfoResponse getKaKaoUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + kakaoAccessToken);
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
+                kakaoProps.user_info_url(),
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfoResponse.class
+            );
+
+            if(!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+                log.debug("response에서 에러 발생" + response);
+                throw new NeighborsException(KAKAO_USER_INFO_NOT_FOUND);
+            }
+            return response.getBody();
+        } catch (RestClientException e) {
+            log.debug("에러 발생: " + e.getMessage());
+            throw new NeighborsException(KAKAO_USER_INFO_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/gonggoo/gonggoo/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/gonggoo/gonggoo/common/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.gonggoo.gonggoo.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/gonggoo/gonggoo/common/domain/GeoLocation.java
+++ b/src/main/java/com/gonggoo/gonggoo/common/domain/GeoLocation.java
@@ -10,11 +10,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GeoLocation {
 
-    @Column(nullable = false)
-    private double latitude;
+    @Column
+    private Double latitude;
 
-    @Column(nullable = false)
-    private double longitude;
+    @Column
+    private Double longitude;
 
     protected GeoLocation() {}
 }

--- a/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
@@ -5,10 +5,12 @@ import static com.gonggoo.gonggoo.global.response.ErrorCode.SERVER_ERROR;
 import com.gonggoo.gonggoo.global.exception.NeighborsException;
 import com.gonggoo.gonggoo.global.response.ApiResponse;
 import com.gonggoo.gonggoo.global.response.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(NeighborsException.class)
@@ -22,6 +24,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         NeighborsException neighborsException =
                 new NeighborsException(SERVER_ERROR);
+        log.debug(e.getMessage());
         ErrorCode errorCode = neighborsException.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode));

--- a/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
@@ -24,7 +24,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         NeighborsException neighborsException =
                 new NeighborsException(SERVER_ERROR);
-        log.debug(e.getMessage());
         ErrorCode errorCode = neighborsException.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode));

--- a/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/handler/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         NeighborsException neighborsException =
                 new NeighborsException(SERVER_ERROR);
+        log.debug(e.getMessage());
         ErrorCode errorCode = neighborsException.getErrorCode();
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode));

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     ROOM_CATEGORY_NOT_FOUND(HttpStatus.NO_CONTENT, "채팅방을 찾을 수 없습니다.", "roomCategory를 찾을 수 없습니다."),
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다", ""),
     CHATROOM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방에 유저가 없습니다.", ""),
-    INVALID_CURSOR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.", "Cursor가 유효하지 않습니다.");
+    INVALID_CURSOR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.", "Cursor가 유효하지 않습니다."),
+    KAKAO_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오 유저 정보를 찾을 수 없습니다.", "카카오 API 오류");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
     CHATROOM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방에 유저가 없습니다.", ""),
     INVALID_CURSOR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.", "Cursor가 유효하지 않습니다."),
     KAKAO_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오 유저 정보를 찾을 수 없습니다.", "카카오 API 오류"),
-    NAVER_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "네이버 유저 정보를 찾을 수 없습니다.", "네이버 API 오류");
+    NAVER_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "네이버 유저 정보를 찾을 수 없습니다.", "네이버 API 오류"),
+    GOOGLE_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "구글 유저 정보를 찾을 수 없습니다.", "구글 API 오류");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다", ""),
     CHATROOM_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방에 유저가 없습니다.", ""),
     INVALID_CURSOR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.", "Cursor가 유효하지 않습니다."),
-    KAKAO_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오 유저 정보를 찾을 수 없습니다.", "카카오 API 오류");
+    KAKAO_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오 유저 정보를 찾을 수 없습니다.", "카카오 API 오류"),
+    NAVER_USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "네이버 유저 정보를 찾을 수 없습니다.", "네이버 API 오류");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/gonggoo/gonggoo/member/domain/Member.java
+++ b/src/main/java/com/gonggoo/gonggoo/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.gonggoo.gonggoo.member.domain;
 
+import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.common.domain.BaseEntity;
 import com.gonggoo.gonggoo.common.domain.GeoLocation;
 import com.gonggoo.gonggoo.common.domain.Role;
@@ -23,14 +24,21 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(name = "phone_number", nullable = false, unique = true)
+    @Column(name = "phone_number", unique = true)
     private String phoneNumber;
 
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RegistrationProvider provider = RegistrationProvider.LOCAL;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
 
     @Column(name = "profile_image")
     private String profileImage;
@@ -47,13 +55,24 @@ public class Member extends BaseEntity {
     private MemberStatus status;
 
     @Builder
-    public Member(String nickname, String phoneNumber, String email, String password, String profileImage, Role role, GeoLocation location, MemberStatus status) {
+    public Member(String nickname,
+                  String phoneNumber,
+                  String email,
+                  String password,
+                  RegistrationProvider provider,
+                  String providerId,
+                  String profileImage,
+                  Role role,
+                  GeoLocation location,
+                  MemberStatus status) {
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.password = password;
-        this.profileImage = "/images/default.png";
-        this.role = Role.USER;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.profileImage = (profileImage != null) ? profileImage : "/images/default.png" ;
+        this.role = (role != null) ? role : Role.USER;
         this.location = location;
         this.status = MemberStatus.ACTIVE;
     }
@@ -75,6 +94,13 @@ public class Member extends BaseEntity {
     }
 
     public void changeLocation(GeoLocation location) {
-        this.location = location;
+        this    .location = location;
+    }
+
+    public Member update(String nickname, String profileImage, String email) {
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.email = email;
+        return this;
     }
 }


### PR DESCRIPTION
## 🔘 Part
- [ ] FE
- [x] BE
- [ ] Other
## #️⃣ 연관된 이슈
<!-- ex) #123 -->
#84 
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 카카오, 네이버, 구글 소셜 로그인 구현
- 로그인 시 프론트에서 요청 url을 보내고 code를 넘겨주면 accessToken 및 회원정보 조회하도록 기능 구현
## 스크린샷 (선택)
## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) {커밋 해시} 커밋을 중점적으로 봐주세요! -->
