### PR TITLE
Fix/#95 api 에러 수정

### DIFF
--- a/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.gonggoo.gonggoo.auth.controller;
 
 import com.gonggoo.gonggoo.auth.dto.LoginRequest;
+import com.gonggoo.gonggoo.auth.dto.LoginResponse;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenDto;
 import com.gonggoo.gonggoo.auth.jwt.JwtTokenProvider;
 import com.gonggoo.gonggoo.auth.service.AuthService;
@@ -20,11 +21,18 @@ public class AuthController {
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(summary = "개발자용 로그인", description = "accessToken과 refreshToken 확인용입니다.")
+    @PostMapping("/login-dev")
+    public ApiResponse<JwtTokenDto> loginForDev(@RequestBody LoginRequest loginRequest) {
+        JwtTokenDto token = authService.loginForDev(loginRequest);
+        return ApiResponse.success("LOGIN_SUCCESS", token);
+    }
+
     @Operation(summary = "로그인", description = "이메일과 비밀번호를 입력하면 로그인됩니다.")
     @PostMapping("/login")
-    public ApiResponse<JwtTokenDto> login(@RequestBody LoginRequest loginRequest) {
-        JwtTokenDto token = authService.login(loginRequest);
-        return ApiResponse.success("LOGIN_SUCCESS", token);
+    public ApiResponse<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        LoginResponse loginResponse = authService.login(loginRequest);
+        return ApiResponse.success("LOGIN_SUCCESS", loginResponse);
     }
 
     @Operation(summary = "토큰 재발행", description = "refreshToken을 통해 토큰을 재발행합니다.")

--- a/src/main/java/com/gonggoo/gonggoo/auth/dto/LoginResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/dto/LoginResponse.java
@@ -1,0 +1,25 @@
+package com.gonggoo.gonggoo.auth.dto;
+
+import com.gonggoo.gonggoo.common.domain.GeoLocation;
+import com.gonggoo.gonggoo.common.domain.Role;
+import com.gonggoo.gonggoo.member.domain.Member;
+
+public record LoginResponse(
+        String nickname,
+        String phoneNumber,
+        String email,
+        String profileImage,
+        Role role,
+        GeoLocation Location
+) {
+    public static LoginResponse from(final Member member) {
+        return new LoginResponse(
+                member.getNickname(),
+                member.getPhoneNumber(),
+                member.getEmail(),
+                member.getProfileImage(),
+                member.getRole(),
+                member.getLocation()
+        );
+    }
+}

--- a/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
+++ b/src/main/java/com/gonggoo/gonggoo/auth/service/AuthService.java
@@ -2,10 +2,14 @@ package com.gonggoo.gonggoo.auth.service;
 
 import static com.gonggoo.gonggoo.global.response.ErrorCode.GOOGLE_USER_INFO_NOT_FOUND;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.KAKAO_USER_INFO_NOT_FOUND;
+import static com.gonggoo.gonggoo.global.response.ErrorCode.MEMBER_LOGIN_FAILED;
+import static com.gonggoo.gonggoo.global.response.ErrorCode.MEMBER_NOT_FOUND;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.NAVER_USER_INFO_NOT_FOUND;
+import static com.gonggoo.gonggoo.global.response.ErrorCode.PASSWORD_FAILED;
 
 import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.auth.dto.LoginRequest;
+import com.gonggoo.gonggoo.auth.dto.LoginResponse;
 import com.gonggoo.gonggoo.auth.google.GoogleProps;
 import com.gonggoo.gonggoo.auth.google.GoogleTokenResponse;
 import com.gonggoo.gonggoo.auth.google.GoogleUserInfoResponse;
@@ -50,11 +54,21 @@ public class AuthService {
     private final GoogleProps googleProps;
     private final RestTemplate restTemplate;
 
-    public JwtTokenDto login(LoginRequest loginRequest) {
+    public LoginResponse login(LoginRequest loginRequest) {
         Member member = memberRepository.findByEmail(loginRequest.email())
-                .orElseThrow(() -> new IllegalStateException("요청한 이메일에 해당하는 회원이 없습니다."));
+                .orElseThrow(() -> new NeighborsException(MEMBER_LOGIN_FAILED));
+        if (!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
+            throw new NeighborsException(PASSWORD_FAILED);
+        }
+
+        return LoginResponse.from(member);
+    }
+
+    public JwtTokenDto loginForDev(LoginRequest loginRequest) {
+        Member member = memberRepository.findByEmail(loginRequest.email())
+                .orElseThrow(() -> new NeighborsException(MEMBER_NOT_FOUND));
         if(!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
-            throw new IllegalStateException("비밀번호가 틀렸습니다.");
+            throw new NeighborsException(PASSWORD_FAILED);
         }
 
         var accessToken = jwtTokenProvider.generateToken(String.valueOf(member.getId()), member.getRole());

--- a/src/main/java/com/gonggoo/gonggoo/coopost/domain/Coopost.java
+++ b/src/main/java/com/gonggoo/gonggoo/coopost/domain/Coopost.java
@@ -106,6 +106,7 @@ public class Coopost extends BaseEntity {
         if (req.getTitle() != null) this.title = req.getTitle();
         if (req.getContent() != null) this.content = req.getContent();
         if (req.getPricePerUnit() != null) this.pricePerUnit = req.getPricePerUnit();
+        if (req.getOriginalPrice() != null) this.originalPrice = req.getOriginalPrice();
         if (req.getMinParticipants() != null) this.minParticipants = req.getMinParticipants();
         if (req.getMaxParticipants() != null) this.maxParticipants = req.getMaxParticipants();
         if (req.getCategory() != null) this.category = req.getCategory();

--- a/src/main/java/com/gonggoo/gonggoo/coopost/dto/request/CoopostUpdateRequest.java
+++ b/src/main/java/com/gonggoo/gonggoo/coopost/dto/request/CoopostUpdateRequest.java
@@ -12,6 +12,7 @@ public class CoopostUpdateRequest {
     private String title;
     private String content;
     private BigDecimal pricePerUnit;
+    private BigDecimal originalPrice;
     private Integer minParticipants;
     private Integer maxParticipants;
     private CoopostCategory category;

--- a/src/main/java/com/gonggoo/gonggoo/coopost/dto/response/CoopostResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/coopost/dto/response/CoopostResponse.java
@@ -19,6 +19,7 @@ public class CoopostResponse {
     CoopostStatus status;
 
     BigDecimal pricePerUnit;
+    BigDecimal originalPrice;
     Integer minParticipants;
     Integer maxParticipants;
     Integer currentParticipants;
@@ -47,6 +48,7 @@ public class CoopostResponse {
                 .title(e.getTitle())
                 .content(e.getContent())
                 .status(e.getStatus())
+                .originalPrice(e.getOriginalPrice())
                 .pricePerUnit(e.getPricePerUnit())
                 .minParticipants(e.getMinParticipants())
                 .maxParticipants(e.getMaxParticipants())

--- a/src/main/java/com/gonggoo/gonggoo/coopost/service/CoopostServiceImpl.java
+++ b/src/main/java/com/gonggoo/gonggoo/coopost/service/CoopostServiceImpl.java
@@ -50,7 +50,7 @@ public class CoopostServiceImpl implements CoopostService {
             .pricePerUnit(req.getPricePerUnit())
             .minParticipants(req.getMinParticipants())
             .maxParticipants(req.getMaxParticipants())
-            .currentParticipants(0)
+            .currentParticipants(1)
             .category(Optional.ofNullable(req.getCategory()).orElse(CoopostCategory.ELSE))
             .location(req.getLocation())
             .deadlineAt(req.getDeadlineAt())

--- a/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
+++ b/src/main/java/com/gonggoo/gonggoo/global/response/ErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다.", "Member 엔티티가 db 안에 존재하지 않습니다"),
+    MEMBER_LOGIN_FAILED(HttpStatus.NOT_FOUND, "회원가입이 되어있지 않은 이메일입니다.", "이메일이 db안에 존재하지 않습니다"),
+    PASSWORD_FAILED(HttpStatus.NOT_FOUND, "비밀번호가 틀렸습니다.", "비밀번호가 일치하지 않습니다."),
     INVALID_JWT(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다", "토큰의 Claim이 일치하지 않습니다"),
     DUPLICATE_MEMBER_EMAIL(HttpStatus.BAD_REQUEST, "이미 등록된 이메일입니다", "같은 이메일이 존재합니다"),
     DUPLICATE_MEMBER_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "이미 등록된 전화번호입니다", "같은 전화번호가 존재합니다"),

--- a/src/main/java/com/gonggoo/gonggoo/member/dto/request/MemberSignupRequest.java
+++ b/src/main/java/com/gonggoo/gonggoo/member/dto/request/MemberSignupRequest.java
@@ -1,5 +1,6 @@
 package com.gonggoo.gonggoo.member.dto.request;
 
+import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.common.domain.GeoLocation;
 
 public record MemberSignupRequest(
@@ -7,6 +8,8 @@ public record MemberSignupRequest(
         String phoneNumber,
         String email,
         String password,
+        RegistrationProvider provider,
+        String providerId,
         GeoLocation location
 ) {
 }

--- a/src/main/java/com/gonggoo/gonggoo/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/gonggoo/gonggoo/member/dto/response/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.gonggoo.gonggoo.member.dto.response;
 
 
+import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.common.domain.GeoLocation;
 import com.gonggoo.gonggoo.common.domain.Role;
 import com.gonggoo.gonggoo.member.domain.Member;
@@ -13,6 +14,8 @@ public record MemberResponse (
         String email,
         String profileImage,
         Role role,
+        RegistrationProvider provider,
+        String providerId,
         GeoLocation location,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt,
@@ -26,6 +29,8 @@ public record MemberResponse (
                 member.getEmail(),
                 member.getProfileImage(),
                 member.getRole(),
+                member.getProvider(),
+                member.getProviderId(),
                 member.getLocation(),
                 member.getCreatedAt(),
                 member.getModifiedAt(),

--- a/src/main/java/com/gonggoo/gonggoo/member/service/MemberService.java
+++ b/src/main/java/com/gonggoo/gonggoo/member/service/MemberService.java
@@ -1,9 +1,11 @@
 package com.gonggoo.gonggoo.member.service;
 
+import static com.gonggoo.gonggoo.auth.domain.RegistrationProvider.*;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.DUPLICATE_MEMBER_EMAIL;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.DUPLICATE_MEMBER_PHONE_NUMBER;
 import static com.gonggoo.gonggoo.global.response.ErrorCode.MEMBER_NOT_FOUND;
 
+import com.gonggoo.gonggoo.auth.domain.RegistrationProvider;
 import com.gonggoo.gonggoo.common.domain.GeoLocation;
 import com.gonggoo.gonggoo.global.exception.NeighborsException;
 import com.gonggoo.gonggoo.member.domain.Member;
@@ -18,6 +20,7 @@ import com.gonggoo.gonggoo.member.dto.response.PhoneNumberCheckResponse;
 import com.gonggoo.gonggoo.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +46,8 @@ public class MemberService {
                 .phoneNumber(request.phoneNumber())
                 .email(request.email())
                 .password(hashedPassword)
+                .provider(LOCAL)
+                .providerId(String.valueOf(UUID.randomUUID()))
                 .location(geolocation)
                 .build();
 

--- a/src/main/java/com/gonggoo/gonggoo/security/config/SecurityConfig.java
+++ b/src/main/java/com/gonggoo/gonggoo/security/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui.html").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/member/v1/signup").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/member/v1/check-email/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,"/api/member/v1/check-nickname/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/v1/login").permitAll()
                         .requestMatchers("/api/v1/notification/**").permitAll()
                         .requestMatchers("/api/device/**").permitAll()


### PR DESCRIPTION
## 🔘 Part
- [ ] FE
- [x] BE
- [ ] Other
## #️⃣ 연관된 이슈
<!-- ex) #123 -->
#95 
## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
API 연동 시 에러나는 부분들 수정
1. securityFilter에서 이메일/닉네임 중복 확인 permit 수정
2. 로컬 회원가입 시 provider, providerId 기본값으로 들어가도록 수정
3. 로그인 시 회원 정보를 반환하도록 수정
4. 공구글 API에서 CoopostResponse에 originalPrice 포함
5. 공구글 생성 시 currentParticipants를 1로 수정
## 스크린샷 (선택)
## 💬 리뷰 요구사항(선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) {커밋 해시} 커밋을 중점적으로 봐주세요! -->
